### PR TITLE
Fixed crashing capture-gui with shiboken

### DIFF
--- a/capture_gui/__init__.py
+++ b/capture_gui/__init__.py
@@ -1,3 +1,5 @@
+from . import app
+from . import lib
 
 
 def main(show=True):
@@ -12,15 +14,11 @@ def main(show=True):
         capture_gui.app.App: The pyblish gui application instance.
 
     """
-    from . import app
-    from . import lib
-
     # get main maya window to parent widget to
     parent = lib.get_maya_main_window()
 
     # launch app
-    window = app.App(title="Capture GUI",
-                     parent=parent)
+    window = app.App(title="Capture GUI", parent=parent)
 
     if show:
         window.show()

--- a/capture_gui/lib.py
+++ b/capture_gui/lib.py
@@ -1,3 +1,5 @@
+# TODO: find a solution for fetching Maya main window without shiboken and crashes
+
 import sys
 import logging
 import json
@@ -9,9 +11,16 @@ import contextlib
 import datetime
 import maya.cmds as cmds
 import maya.mel as mel
+import maya.OpenMayaUI as omui
 import capture
 
 from .vendor.Qt import QtWidgets
+try:
+    # PySide1
+    import shiboken
+except ImportError:
+    # PySide2
+    import shiboken2 as shiboken
 
 log = logging.getLogger(__name__)
 
@@ -363,7 +372,10 @@ def no_undo():
 
 
 def get_maya_main_window():
-    """Return Maya's main window"""
-    for obj in QtWidgets.QApplication.topLevelWidgets():
-        if obj.objectName() == 'MayaWindow':
-            return obj
+    """
+    Get the main Maya window as a QtGui.QMainWindow instance
+    :return: QtGui.QMainWindow instance of the top level Maya windows
+    """
+    ptr = omui.MQtUtil.mainWindow()
+    if ptr is not None:
+        return shiboken.wrapInstance(long(ptr), QtWidgets.QWidget)


### PR DESCRIPTION
In order to stop the UI from crashing at launch and letting Maya crash we have switched to shiboken.