### PR TITLE
Improve clarity of saving behavior

### DIFF
--- a/capture_gui/lib.py
+++ b/capture_gui/lib.py
@@ -302,20 +302,8 @@ def browse(path=None):
             # Scene wasn't saved yet so found no valid name for playblast.
             default_filename = "playblast"
 
-        # Default to images rule (if rule exists in workspace)
-        images_rule = cmds.workspace(variableEntry="images")
-        if images_rule:
-            root = cmds.workspace(query=True, rootDirectory=True)
-            default_root = os.path.join(root, images_rule)
-        else:
-            # start browser at last browsed directory
-            default_root = cmds.workspace(query=True, directory=True)
-
-        # This should never be the case, but just to be safe.
-        if default_root is None:
-            raise RuntimeError("defaultRoot couldn't be defined. "
-                               "Contact your local Technical Director!")
-
+        # Default to images rule
+        default_root = os.path.normpath(get_project_rule("images"))
         default_path = os.path.join(default_root, default_filename)
         path = cmds.fileDialog2(fileMode=0,
                                 dialogStyle=2,

--- a/capture_gui/plugins/ioplugin.py
+++ b/capture_gui/plugins/ioplugin.py
@@ -72,7 +72,10 @@ class IoPlugin(plugin.Plugin):
 
         self.browse = QtWidgets.QPushButton("Browse")
         self.file_path = QtWidgets.QLineEdit()
-        self.file_path.setPlaceholderText("Select a directory")
+        self.file_path.setPlaceholderText("(not set; using scene name)")
+        tip = "Right click in the text field to insert tokens"
+        self.file_path.setToolTip(tip)
+        self.file_path.setStatusTip(tip)
         self.file_path.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         self.file_path.customContextMenuRequested.connect(self.show_token_menu)
 

--- a/capture_gui/plugins/ioplugin.py
+++ b/capture_gui/plugins/ioplugin.py
@@ -104,7 +104,11 @@ class IoPlugin(plugin.Plugin):
 
         # Maya's browser return Linux based file paths to ensure Windows is
         # supported we use normpath
-        self.file_path.setText(os.path.normpath(lib.browse()))
+        path = lib.browse()
+        if not path:
+            return
+
+        self.file_path.setText(os.path.normpath(path))
 
     def add_playblast(self, item):
         """

--- a/capture_gui/plugins/ioplugin.py
+++ b/capture_gui/plugins/ioplugin.py
@@ -67,8 +67,8 @@ class IoPlugin(plugin.Plugin):
         checkbox_hlayout.addStretch(True)
         # endregion Checkboxes
 
-        # region Directory
-        self.dir_widget = QtWidgets.QWidget()
+        # region Path
+        self.path_widget = QtWidgets.QWidget()
 
         self.browse = QtWidgets.QPushButton("Browse")
         self.file_path = QtWidgets.QLineEdit()
@@ -79,16 +79,16 @@ class IoPlugin(plugin.Plugin):
         self.file_path.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         self.file_path.customContextMenuRequested.connect(self.show_token_menu)
 
-        dir_hlayout = QtWidgets.QHBoxLayout()
-        dir_hlayout.setContentsMargins(0, 0, 0, 0)
-        dir_label = QtWidgets.QLabel("Directory :")
-        dir_label.setFixedWidth(60)
+        path_hlayout = QtWidgets.QHBoxLayout()
+        path_hlayout.setContentsMargins(0, 0, 0, 0)
+        path_label = QtWidgets.QLabel("Path:")
+        path_label.setFixedWidth(30)
 
-        dir_hlayout.addWidget(dir_label)
-        dir_hlayout.addWidget(self.file_path)
-        dir_hlayout.addWidget(self.browse)
-        self.dir_widget.setLayout(dir_hlayout)
-        # endregion Directory
+        path_hlayout.addWidget(path_label)
+        path_hlayout.addWidget(self.file_path)
+        path_hlayout.addWidget(self.browse)
+        self.path_widget.setLayout(path_hlayout)
+        # endregion Path
 
         # region Recent Playblast
         self.play_recent = QtWidgets.QPushButton("Play recent playblast")
@@ -97,21 +97,26 @@ class IoPlugin(plugin.Plugin):
         # endregion Recent Playblast
 
         self._layout.addLayout(checkbox_hlayout)
-        self._layout.addWidget(self.dir_widget)
+        self._layout.addWidget(self.path_widget)
         self._layout.addWidget(self.play_recent)
 
-        self.browse.clicked.connect(self.get_save_directory)
+        self.browse.clicked.connect(self.show_browse_dialog)
 
-    def get_save_directory(self):
-        """Return file path in which the file will be saved"""
+    def show_browse_dialog(self):
+        """Set the filepath using a browser dialog.
+        
+        :return: None
+        """
 
-        # Maya's browser return Linux based file paths to ensure Windows is
-        # supported we use normpath
         path = lib.browse()
         if not path:
             return
 
-        self.file_path.setText(os.path.normpath(path))
+        # Maya's browser return Linux based file paths to ensure Windows is
+        # supported we use normpath
+        path = os.path.normpath(path)
+
+        self.file_path.setText(path)
 
     def add_playblast(self, item):
         """

--- a/capture_gui/plugins/ioplugin.py
+++ b/capture_gui/plugins/ioplugin.py
@@ -110,21 +110,28 @@ class IoPlugin(plugin.Plugin):
         """
         Add an item to the previous playblast menu
         
-        :param item: a collection of file paths of the playblast files
+        :param item: full path to a playblast file
         :type item: str
         
         :return: None 
         """
 
-        if item in self.recent_playblasts:
-            log.info("Item already in list")
-            return
+        # If item already in the recent playblasts remove it so we are
+        # sure to add it as the new first most-recent
+        try:
+            self.recent_playblasts.remove(item)
+        except ValueError:
+            pass
 
-        if len(self.recent_playblasts) == self.max_recent_playblasts:
-            self.recent_playblasts.pop(self.max_recent_playblasts - 1)
-
+        # Add as first in the recent playblasts
         self.recent_playblasts.insert(0, item)
 
+        # Ensure the playblast list is never longer than maximum amount
+        # by removing the older entries that are at the end of the list
+        if len(self.recent_playblasts) > self.max_recent_playblasts:
+            self.recent_playblasts[:] = self.recent_playblasts[:self.max_recent_playblasts]
+
+        # Rebuild the actions menu
         self.recent_menu.clear()
         for playblast in self.recent_playblasts:
             action = IoAction(parent=self, filepath=playblast)

--- a/capture_gui/plugins/ioplugin.py
+++ b/capture_gui/plugins/ioplugin.py
@@ -129,7 +129,7 @@ class IoPlugin(plugin.Plugin):
         # Ensure the playblast list is never longer than maximum amount
         # by removing the older entries that are at the end of the list
         if len(self.recent_playblasts) > self.max_recent_playblasts:
-            self.recent_playblasts[:] = self.recent_playblasts[:self.max_recent_playblasts]
+            del self.recent_playblasts[self.max_recent_playblasts:]
 
         # Rebuild the actions menu
         self.recent_menu.clear()

--- a/capture_gui/plugins/timeplugin.py
+++ b/capture_gui/plugins/timeplugin.py
@@ -252,7 +252,7 @@ class TimePlugin(capture_gui.plugin.Plugin):
         self.mode.setCurrentIndex(mode)
         self.start.setValue(int(startframe))
         self.end.setValue(int(endframe))
-        if custom_frames:
+        if custom_frames is not None:
             self.custom_frames.setText(custom_frames)
 
     def initialize(self):

--- a/capture_gui/plugins/timeplugin.py
+++ b/capture_gui/plugins/timeplugin.py
@@ -126,6 +126,7 @@ class TimePlugin(capture_gui.plugin.Plugin):
         self.mode.currentIndexChanged.connect(self.on_mode_changed)
         self.start.valueChanged.connect(self.on_mode_changed)
         self.end.valueChanged.connect(self.on_mode_changed)
+        self.custom_frames.textChanged.connect(self.on_mode_changed)
 
     def _ensure_start(self, value):
         self.start.setValue(min(self.start.value(), value))
@@ -159,12 +160,11 @@ class TimePlugin(capture_gui.plugin.Plugin):
             self.end.setVisible(True)
             self.custom_frames.setVisible(False)
             mode_values = self.start.value(), self.end.value()
-
         elif mode == self.CustomFrames:
             self.start.setVisible(False)
             self.end.setVisible(False)
             self.custom_frames.setVisible(True)
-            mode_values = self.custom_frames.text()
+            mode_values = "({})".format(self.custom_frames.text())
         else:
             self.start.setEnabled(False)
             self.end.setEnabled(False)

--- a/capture_gui/plugins/timeplugin.py
+++ b/capture_gui/plugins/timeplugin.py
@@ -63,6 +63,10 @@ def parse_frames(string):
 
             result.append(frame)
 
+    if not result:
+        # This happens when only spaces are entered with a separator like `,` or `;`
+        raise ValueError("Unable to parse any frames from string: {}".format(string))
+
     return result
 
 

--- a/capture_gui/plugins/timeplugin.py
+++ b/capture_gui/plugins/timeplugin.py
@@ -31,9 +31,8 @@ def parse_frames(string):
     """
 
     result = list()
-
-    if not string:
-        return result
+    if not string.strip():
+        raise ValueError("Can't parse an empty frame string.")
 
     if not re.match("^[-0-9,; ]*$", string):
         raise ValueError("Invalid symbols in frame string: {}".format(string))
@@ -43,8 +42,6 @@ def parse_frames(string):
         # Skip empty elements
         value = raw.strip().replace(" ", "")
         if not value:
-            if raw:
-                raise ValueError("Empty frame entry: '{0}'".format(raw))
             continue
 
         # Check for sequences (1-20) including negatives (-10--8)
@@ -107,7 +104,7 @@ class TimePlugin(capture_gui.plugin.Plugin):
         # unique frames field
         self.custom_frames = QtWidgets.QLineEdit()
         self.custom_frames.setFixedHeight(frame_input_height)
-        self.custom_frames.setPlaceholderText("1-20,25;50;75,100-150")
+        self.custom_frames.setPlaceholderText("Example: 1-20,25;50;75,100-150")
         self.custom_frames.setVisible(False)
 
         self._layout.addWidget(self.mode)
@@ -119,7 +116,6 @@ class TimePlugin(capture_gui.plugin.Plugin):
         # and the end is never lower than start
         self.end.valueChanged.connect(self._ensure_start)
         self.start.valueChanged.connect(self._ensure_end)
-        self.custom_frames.textChanged.connect(self.validate)
 
         self.on_mode_changed()  # force enabled state refresh
 
@@ -165,6 +161,10 @@ class TimePlugin(capture_gui.plugin.Plugin):
             self.end.setVisible(False)
             self.custom_frames.setVisible(True)
             mode_values = "({})".format(self.custom_frames.text())
+
+            # ensure validation state for custom frames
+            self.validate()
+
         else:
             self.start.setEnabled(False)
             self.end.setEnabled(False)


### PR DESCRIPTION
- By default browse to the "images" file rule folder, instead of old code that didn't work as expected.
- Fix error when cancelling browsing save location
- Improve readability of default saving behavior through placeholder text
- Set up tooltip and statustip about "insert token" functionality for the filename text field.